### PR TITLE
Added Icons to Filters

### DIFF
--- a/EverythingToolbar/EverythingToolbar.csproj
+++ b/EverythingToolbar/EverythingToolbar.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -188,6 +188,18 @@
     <Page Include="FilterSelector.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Icons\all.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Icons\file.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Icons\folder.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Rules.xaml">
       <SubType>Designer</SubType>

--- a/EverythingToolbar/FilterSelector.xaml
+++ b/EverythingToolbar/FilterSelector.xaml
@@ -1,7 +1,16 @@
-﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:properties="clr-namespace:EverythingToolbar.Properties"
              x:Class="EverythingToolbar.FilterSelector">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="./Icons/all.xaml" x:Name="All"/>
+                <ResourceDictionary Source="./Icons/file.xaml" x:Name="File"/>
+                <ResourceDictionary Source="./Icons/folder.xaml" x:Name="Folder"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
     <Border BorderBrush="{DynamicResource TabBarBorder}"
             BorderThickness="0, 0, 0, 1">
         <StackPanel Orientation="Horizontal">

--- a/EverythingToolbar/Icons/all.xaml
+++ b/EverythingToolbar/Icons/all.xaml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--This file is NOT compatible with Silverlight-->
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DataTemplate x:Key="AllFilterIcon">
+        <Viewbox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Stretch="Uniform">
+          <Canvas Name="svg8" Width="8.598958" Height="10.583333">
+            <Canvas.RenderTransform>
+              <TranslateTransform X="0" Y="0"/>
+            </Canvas.RenderTransform>
+            <Canvas.Resources/>
+            <!--Unknown tag: sodipodi:namedview-->
+            <!--Unknown tag: metadata-->
+            <Canvas Name="layer1">
+              <Canvas.RenderTransform>
+                <TranslateTransform X="-25.607887" Y="-112.54762"/>
+              </Canvas.RenderTransform>
+              <Canvas Name="text828" Opacity="1">
+                <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Name="path830" Fill="#FF000000" StrokeThickness="0.26458332">
+                  <Path.Data>
+                    <PathGeometry Figures="m 25.698124 119.93388 v -1.5875 h 1.5875 v 1.5875 z m 0.529167 -1.05833 v 0.52916 h 0.529166 v -0.52916 z m -0.529167 -1.05834 v -1.5875 h 1.5875 v 1.5875 z m 0.529167 -1.05833 v 0.52917 h 0.529166 v -0.52917 z m -0.529167 -1.05833 v -1.5875 h 1.5875 v 1.5875 z m 0.529167 -1.05834 v 0.52917 h 0.529166 v -0.52917 z m 2.116666 2.64584 v -0.52917 h 4.7625 v 0.52917 z m 3.704167 1.5875 v 0.52916 h -3.704167 v -0.52916 z m -3.704167 -4.23334 h 5.820833 v 0.52917 h -5.820833 z m -2.645833 7.40834 v -1.5875 h 1.5875 v 1.5875 z m 0.529167 -1.05834 v 0.52917 h 0.529166 v -0.52917 z m 2.116666 0.52917 v -0.52917 h 4.7625 v 0.52917 z" FillRule="NonZero"/>
+                  </Path.Data>
+                </Path>
+              </Canvas>
+            </Canvas>
+          </Canvas>
+</Viewbox>
+    </DataTemplate>
+</ResourceDictionary>

--- a/EverythingToolbar/Icons/file.xaml
+++ b/EverythingToolbar/Icons/file.xaml
@@ -1,27 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This file is NOT compatible with Silverlight-->
-<Viewbox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Stretch="Uniform">
-  <Canvas Name="svg8" Width="8.598958" Height="10.583333">
-    <Canvas.RenderTransform>
-      <TranslateTransform X="0" Y="0"/>
-    </Canvas.RenderTransform>
-    <Canvas.Resources/>
-    <!--Unknown tag: sodipodi:namedview-->
-    <!--Unknown tag: metadata-->
-    <Canvas Name="layer1">
-      <Canvas.RenderTransform>
-        <TranslateTransform X="-25.607887" Y="-112.54762"/>
-      </Canvas.RenderTransform>
-      <Canvas Name="text824" Opacity="1">
-        <Canvas.RenderTransform>
-          <TranslateTransform X="-14.866867" Y="-0.3674956"/>
-        </Canvas.RenderTransform>
-        <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Name="path833" Fill="#FF000000" StrokeThickness="0.26458332">
-          <Path.Data>
-            <PathGeometry Figures="m 48.190483 116.23232 v 6.19704 h -6.879166 v -8.46667 h 4.609537 z m -2.116666 -0.15296 h 1.211295 l -1.211295 -1.2113 z m 1.5875 5.82083 v -5.29166 H 45.54465 v -2.11667 h -3.704166 v 7.40833 z" FillRule="NonZero"/>
-          </Path.Data>
-        </Path>
-      </Canvas>
-    </Canvas>
-  </Canvas>
-</Viewbox>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DataTemplate x:Key="FileFilterIcon">
+        <Viewbox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Stretch="Uniform">
+            <Canvas Name="svg8" Width="8.598958" Height="10.583333">
+                <Canvas.RenderTransform>
+                    <TranslateTransform X="0" Y="0"/>
+                </Canvas.RenderTransform>
+                <Canvas.Resources/>
+                <!--Unknown tag: sodipodi:namedview-->
+                <!--Unknown tag: metadata-->
+                <Canvas Name="layer1">
+                    <Canvas.RenderTransform>
+                        <TranslateTransform X="-25.607887" Y="-112.54762"/>
+                    </Canvas.RenderTransform>
+                    <Canvas Name="text824" Opacity="1">
+                        <Canvas.RenderTransform>
+                            <TranslateTransform X="-14.866867" Y="-0.3674956"/>
+                        </Canvas.RenderTransform>
+                        <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Name="path833" Fill="#FF000000" StrokeThickness="0.26458332">
+                            <Path.Data>
+                                <PathGeometry Figures="m 48.190483 116.23232 v 6.19704 h -6.879166 v -8.46667 h 4.609537 z m -2.116666 -0.15296 h 1.211295 l -1.211295 -1.2113 z m 1.5875 5.82083 v -5.29166 H 45.54465 v -2.11667 h -3.704166 v 7.40833 z" FillRule="NonZero"/>
+                            </Path.Data>
+                        </Path>
+                    </Canvas>
+                </Canvas>
+            </Canvas>
+        </Viewbox>
+    </DataTemplate>
+</ResourceDictionary>

--- a/EverythingToolbar/Icons/file.xaml
+++ b/EverythingToolbar/Icons/file.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--This file is NOT compatible with Silverlight-->
+<Viewbox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Stretch="Uniform">
+  <Canvas Name="svg8" Width="8.598958" Height="10.583333">
+    <Canvas.RenderTransform>
+      <TranslateTransform X="0" Y="0"/>
+    </Canvas.RenderTransform>
+    <Canvas.Resources/>
+    <!--Unknown tag: sodipodi:namedview-->
+    <!--Unknown tag: metadata-->
+    <Canvas Name="layer1">
+      <Canvas.RenderTransform>
+        <TranslateTransform X="-25.607887" Y="-112.54762"/>
+      </Canvas.RenderTransform>
+      <Canvas Name="text824" Opacity="1">
+        <Canvas.RenderTransform>
+          <TranslateTransform X="-14.866867" Y="-0.3674956"/>
+        </Canvas.RenderTransform>
+        <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Name="path833" Fill="#FF000000" StrokeThickness="0.26458332">
+          <Path.Data>
+            <PathGeometry Figures="m 48.190483 116.23232 v 6.19704 h -6.879166 v -8.46667 h 4.609537 z m -2.116666 -0.15296 h 1.211295 l -1.211295 -1.2113 z m 1.5875 5.82083 v -5.29166 H 45.54465 v -2.11667 h -3.704166 v 7.40833 z" FillRule="NonZero"/>
+          </Path.Data>
+        </Path>
+      </Canvas>
+    </Canvas>
+  </Canvas>
+</Viewbox>

--- a/EverythingToolbar/Icons/folder.xaml
+++ b/EverythingToolbar/Icons/folder.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--This file is NOT compatible with Silverlight-->
+<Viewbox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Stretch="Uniform">
+  <Canvas Name="svg8" Width="8.598958" Height="10.583333">
+    <Canvas.RenderTransform>
+      <TranslateTransform X="0" Y="0"/>
+    </Canvas.RenderTransform>
+    <Canvas.Resources/>
+    <!--Unknown tag: sodipodi:namedview-->
+    <!--Unknown tag: metadata-->
+    <Canvas Name="layer1">
+      <Canvas.RenderTransform>
+        <TranslateTransform X="-25.607887" Y="-112.54762"/>
+      </Canvas.RenderTransform>
+      <Canvas Name="text817" Opacity="1">
+        <Canvas.RenderTransform>
+          <TranslateTransform X="-14.967093" Y="-9.8889725"/>
+        </Canvas.RenderTransform>
+        <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Name="path836" Fill="#FF000000" StrokeThickness="0.26458332">
+          <Path.Data>
+            <PathGeometry Figures="m 47.260411 123.41735 q 0.111621 0 0.206706 0.0413 0.09508 0.0413 0.165364 0.11576 0.07441 0.0703 0.115755 0.16536 0.04134 0.0951 0.04134 0.20671 v 4.10104 q 0 0.12816 0.03721 0.22738 0.04134 0.0951 0.09922 0.1819 0.05788 0.0827 0.128158 0.16536 0.07028 0.0827 0.128157 0.19017 0.05788 0.10335 0.09508 0.23978 0.04134 0.13229 0.04134 0.31833 v 1.98437 q 0 0.11162 -0.04134 0.20671 -0.04134 0.0951 -0.115755 0.1695 -0.07028 0.0703 -0.165365 0.11162 -0.09508 0.0413 -0.206705 0.0413 h -6.35 v -8.46667 z m -5.291666 7.9375 h 4.762499 v -1.98437 q 0 -0.18604 0.03721 -0.31833 0.04134 -0.13643 0.09922 -0.23978 0.05788 -0.10749 0.128158 -0.19017 0.07028 -0.0827 0.128157 -0.16536 0.05788 -0.0868 0.09509 -0.1819 0.04134 -0.0992 0.04134 -0.22738 v -4.10104 h -5.291666 z m 5.820833 -1.98437 q 0 -0.0992 -0.02067 -0.17364 -0.01654 -0.0744 -0.05374 -0.13642 -0.03307 -0.062 -0.08268 -0.11989 -0.04547 -0.062 -0.107487 -0.13229 -0.06201 0.0703 -0.111621 0.13229 -0.04548 0.0579 -0.08268 0.11989 -0.03307 0.062 -0.05374 0.13642 -0.01654 0.0744 -0.01654 0.17364 v 1.98437 h 0.529167 z" FillRule="NonZero"/>
+          </Path.Data>
+        </Path>
+      </Canvas>
+    </Canvas>
+  </Canvas>
+</Viewbox>

--- a/EverythingToolbar/Icons/folder.xaml
+++ b/EverythingToolbar/Icons/folder.xaml
@@ -1,27 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--This file is NOT compatible with Silverlight-->
-<Viewbox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Stretch="Uniform">
-  <Canvas Name="svg8" Width="8.598958" Height="10.583333">
-    <Canvas.RenderTransform>
-      <TranslateTransform X="0" Y="0"/>
-    </Canvas.RenderTransform>
-    <Canvas.Resources/>
-    <!--Unknown tag: sodipodi:namedview-->
-    <!--Unknown tag: metadata-->
-    <Canvas Name="layer1">
-      <Canvas.RenderTransform>
-        <TranslateTransform X="-25.607887" Y="-112.54762"/>
-      </Canvas.RenderTransform>
-      <Canvas Name="text817" Opacity="1">
-        <Canvas.RenderTransform>
-          <TranslateTransform X="-14.967093" Y="-9.8889725"/>
-        </Canvas.RenderTransform>
-        <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Name="path836" Fill="#FF000000" StrokeThickness="0.26458332">
-          <Path.Data>
-            <PathGeometry Figures="m 47.260411 123.41735 q 0.111621 0 0.206706 0.0413 0.09508 0.0413 0.165364 0.11576 0.07441 0.0703 0.115755 0.16536 0.04134 0.0951 0.04134 0.20671 v 4.10104 q 0 0.12816 0.03721 0.22738 0.04134 0.0951 0.09922 0.1819 0.05788 0.0827 0.128158 0.16536 0.07028 0.0827 0.128157 0.19017 0.05788 0.10335 0.09508 0.23978 0.04134 0.13229 0.04134 0.31833 v 1.98437 q 0 0.11162 -0.04134 0.20671 -0.04134 0.0951 -0.115755 0.1695 -0.07028 0.0703 -0.165365 0.11162 -0.09508 0.0413 -0.206705 0.0413 h -6.35 v -8.46667 z m -5.291666 7.9375 h 4.762499 v -1.98437 q 0 -0.18604 0.03721 -0.31833 0.04134 -0.13643 0.09922 -0.23978 0.05788 -0.10749 0.128158 -0.19017 0.07028 -0.0827 0.128157 -0.16536 0.05788 -0.0868 0.09509 -0.1819 0.04134 -0.0992 0.04134 -0.22738 v -4.10104 h -5.291666 z m 5.820833 -1.98437 q 0 -0.0992 -0.02067 -0.17364 -0.01654 -0.0744 -0.05374 -0.13642 -0.03307 -0.062 -0.08268 -0.11989 -0.04547 -0.062 -0.107487 -0.13229 -0.06201 0.0703 -0.111621 0.13229 -0.04548 0.0579 -0.08268 0.11989 -0.03307 0.062 -0.05374 0.13642 -0.01654 0.0744 -0.01654 0.17364 v 1.98437 h 0.529167 z" FillRule="NonZero"/>
-          </Path.Data>
-        </Path>
-      </Canvas>
-    </Canvas>
-  </Canvas>
-</Viewbox>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DataTemplate x:Key="FolderFilterIcon">
+        <Viewbox xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" Stretch="Uniform">
+            <Canvas Name="svg8" Width="8.598958" Height="10.583333">
+                <Canvas.RenderTransform>
+                    <TranslateTransform X="0" Y="0"/>
+                </Canvas.RenderTransform>
+                <Canvas.Resources/>
+                <!--Unknown tag: sodipodi:namedview-->
+                <!--Unknown tag: metadata-->
+                <Canvas Name="layer1">
+                    <Canvas.RenderTransform>
+                        <TranslateTransform X="-25.607887" Y="-112.54762"/>
+                    </Canvas.RenderTransform>
+                    <Canvas Name="text817" Opacity="1">
+                        <Canvas.RenderTransform>
+                            <TranslateTransform X="-14.967093" Y="-9.8889725"/>
+                        </Canvas.RenderTransform>
+                        <Path xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Name="path836" Fill="#FF000000" StrokeThickness="0.26458332">
+                            <Path.Data>
+                                <PathGeometry Figures="m 47.260411 123.41735 q 0.111621 0 0.206706 0.0413 0.09508 0.0413 0.165364 0.11576 0.07441 0.0703 0.115755 0.16536 0.04134 0.0951 0.04134 0.20671 v 4.10104 q 0 0.12816 0.03721 0.22738 0.04134 0.0951 0.09922 0.1819 0.05788 0.0827 0.128158 0.16536 0.07028 0.0827 0.128157 0.19017 0.05788 0.10335 0.09508 0.23978 0.04134 0.13229 0.04134 0.31833 v 1.98437 q 0 0.11162 -0.04134 0.20671 -0.04134 0.0951 -0.115755 0.1695 -0.07028 0.0703 -0.165365 0.11162 -0.09508 0.0413 -0.206705 0.0413 h -6.35 v -8.46667 z m -5.291666 7.9375 h 4.762499 v -1.98437 q 0 -0.18604 0.03721 -0.31833 0.04134 -0.13643 0.09922 -0.23978 0.05788 -0.10749 0.128158 -0.19017 0.07028 -0.0827 0.128157 -0.16536 0.05788 -0.0868 0.09509 -0.1819 0.04134 -0.0992 0.04134 -0.22738 v -4.10104 h -5.291666 z m 5.820833 -1.98437 q 0 -0.0992 -0.02067 -0.17364 -0.01654 -0.0744 -0.05374 -0.13642 -0.03307 -0.062 -0.08268 -0.11989 -0.04547 -0.062 -0.107487 -0.13229 -0.06201 0.0703 -0.111621 0.13229 -0.04548 0.0579 -0.08268 0.11989 -0.03307 0.062 -0.05374 0.13642 -0.01654 0.0744 -0.01654 0.17364 v 1.98437 h 0.529167 z" FillRule="NonZero"/>
+                            </Path.Data>
+                        </Path>
+                    </Canvas>
+                </Canvas>
+            </Canvas>
+        </Viewbox>
+    </DataTemplate>
+</ResourceDictionary>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7118300/107140700-47acff80-6967-11eb-9f32-eb0a000197f9.png)


I just added some icons at the tabs(filters), icons from *Segoe MDL2 Assets*, which enhances visibility or visually appealing.
Icons are only applied to all / folder/files since I couldn't find proper icons in glyphs.