### PR TITLE
Add support for building EverythingToolbar on Windows ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,36 +4,45 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: windows-2025
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: windows-2025
+            arch: x64
+            installer: Installer-x64.iss
+          - runner: windows-11-arm
+            arch: arm64
+            installer: Installer-arm64.iss
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
+        
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
-
+        
       - name: Install NuGet
         uses: nuget/setup-nuget@v1
-
+        
       - name: Restore NuGet dependencies
         run: nuget restore
-
+        
       - name: Decode certificate
         shell: bash
         run: echo ${{ secrets.PFX_CERTIFICATE_FILE }} | base64 --decode  > ./EverythingToolbar.snk
-
+        
       - name: Build all
-        run: MSBuild $Env:GITHUB_WORKSPACE /p:Configuration=Release
-
+        run: MSBuild $Env:GITHUB_WORKSPACE /p:Configuration=Release /p:Platform=${{ matrix.arch }}
+        
       - name: Install Inno Setup
         run: choco install innosetup -y --version 6.4.0
-
+        
       - name: Build installer
-        run: iscc "Installer\Installer-x64.iss"
-
+        run: iscc "Installer\${{ matrix.installer }}"
+        
       - name: Upload installer artifact
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: EverythingToolbar-Installer
+          name: EverythingToolbar-Installer-${{ matrix.arch }}
           path: Installer/Output/*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,16 @@ on:
 
 jobs:
   build-release:
-    runs-on: windows-2025
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: windows-2025
+            arch: x64
+            installer: Installer-x64.iss
+          - runner: windows-11-arm
+            arch: arm64
+            installer: Installer-arm64.iss
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -26,32 +35,32 @@ jobs:
         run: echo ${{ secrets.PFX_CERTIFICATE_FILE }} | base64 --decode  > ./EverythingToolbar.snk
 
       - name: Build all
-        run: MSBuild $Env:GITHUB_WORKSPACE /p:Configuration=Release
+        run: MSBuild $Env:GITHUB_WORKSPACE /p:Configuration=Release /p:Platform=${{ matrix.arch }}
 
       - name: Install Inno Setup
         run: choco install innosetup -y --version 6.4.0
 
       - name: Build installer
-        run: iscc /F"EverythingToolbar-${{ github.ref_name }}-x64" "Installer\Installer-x64.iss"
+        run: iscc /F"EverythingToolbar-${{ github.ref_name }}-${{ matrix.arch }}" "Installer\${{ matrix.installer }}"
 
       - name: Generate SHA-256 checksum
         shell: bash
-        run: sha256sum Installer/output/EverythingToolbar-${{ github.ref_name }}-x64.exe > Installer/output/EverythingToolbar-${{ github.ref_name }}-x64.sha256
+        run: sha256sum Installer/output/EverythingToolbar-${{ github.ref_name }}-${{ matrix.arch }}.exe > Installer/output/EverythingToolbar-${{ github.ref_name }}-${{ matrix.arch }}.sha256
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: EverythingToolbar ${{ github.ref_name }}
+          name: EverythingToolbar ${{ github.ref_name }} ${{ matrix.arch }}
           path: |
-            Installer/output/EverythingToolbar-${{ github.ref_name }}-x64.exe
-            Installer/output/EverythingToolbar-${{ github.ref_name }}-x64.sha256
+            Installer/output/EverythingToolbar-${{ github.ref_name }}-${{ matrix.arch }}.exe
+            Installer/output/EverythingToolbar-${{ github.ref_name }}-${{ matrix.arch }}.sha256
 
       - name: Create release draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ github.ref_name }}" `
-            "Installer/output/EverythingToolbar-${{ github.ref_name }}-x64.exe" `
-            "Installer/output/EverythingToolbar-${{ github.ref_name }}-x64.sha256" `
+            "Installer/output/EverythingToolbar-${{ github.ref_name }}-${{ matrix.arch }}.exe" `
+            "Installer/output/EverythingToolbar-${{ github.ref_name }}-${{ matrix.arch }}.sha256" `
             --draft `
             --title "${{ github.ref_name }}"

--- a/EverythingSDK/EverythingSDK.vcxproj
+++ b/EverythingSDK/EverythingSDK.vcxproj
@@ -131,7 +131,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>false</OmitFramePointers>
       <WholeProgramOptimization>false</WholeProgramOptimization>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PrePreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/EverythingSDK/EverythingSDK.vcxproj
+++ b/EverythingSDK/EverythingSDK.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Everything.c" />
@@ -38,6 +46,17 @@
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -46,6 +65,14 @@
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
   </ImportGroup>
@@ -59,6 +86,16 @@
     <TargetName>Everything64</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>Everything64</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <OutDir>$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>Everything64</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <TargetName>Everything64</TargetName>
@@ -94,7 +131,7 @@
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>false</OmitFramePointers>
       <WholeProgramOptimization>false</WholeProgramOptimization>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PrePreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -109,6 +146,54 @@
       <OutputFile>$(OutDir)Everything64.dll</OutputFile>
       <ModuleDefinitionFile>$(ProjectDir)src\Everything64.def</ModuleDefinitionFile>
       <TargetMachine>MachineX64</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Midl>
+      <TargetEnvironment>ARM64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)Everything.lib</OutputFile>
+    </Lib>
+    <Link>
+      <OutputFile>$(OutDir)Everything64.dll</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <Midl>
+      <TargetEnvironment>ARM64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <OmitFramePointers>false</OmitFramePointers>
+      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <FloatingPointModel>Fast</FloatingPointModel>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat />
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <Link>
+      <OutputFile>$(OutDir)Everything64.dll</OutputFile>
+      <ModuleDefinitionFile>$(ProjectDir)src\Everything64.def</ModuleDefinitionFile>
+      <TargetMachine>MachineARM64</TargetMachine>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/EverythingToolbar.Deskband/EverythingToolbar.Deskband.csproj
+++ b/EverythingToolbar.Deskband/EverythingToolbar.Deskband.csproj
@@ -11,6 +11,7 @@
     <EnableComHosting>true</EnableComHosting>
     <GenerateComInterfaceMetadata>true</GenerateComInterfaceMetadata>
     <Nullable>enable</Nullable>
+    <Platforms>x64;ARM64</Platforms>
   </PropertyGroup>
   <PropertyGroup>
     <RunPostBuildEvent>Always</RunPostBuildEvent>
@@ -19,6 +20,12 @@
     <DefineConstants>DESKBAND_WPF</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DefineConstants>TRACE;DEBUG;DESKBAND_WPF</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM64'">
+    <DefineConstants>DESKBAND_WPF</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM64'">
     <DefineConstants>TRACE;DEBUG;DESKBAND_WPF</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
@@ -55,9 +62,14 @@
     <PackageReference Include="NHotkey.Wpf" Version="2.1.0" />
     <PackageReference Include="NLog" Version="5.1.1" />
   </ItemGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='x64'">
     <PreBuildEvent>taskkill /f /im explorer.exe
       xcopy $(SolutionDir)EverythingSDK\x64\$(Configuration)\Everything64.dll $(TargetDir) /r /y
+Exit 0</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='ARM64'">
+    <PreBuildEvent>taskkill /f /im explorer.exe
+      xcopy $(SolutionDir)EverythingSDK\ARM64\$(Configuration)\Everything64.dll $(TargetDir) /r /y
 Exit 0</PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>

--- a/EverythingToolbar.Launcher/EverythingToolbar.Launcher.csproj
+++ b/EverythingToolbar.Launcher/EverythingToolbar.Launcher.csproj
@@ -9,6 +9,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
+    <Platforms>x64;ARM64</Platforms>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Icons\Medium.ico</ApplicationIcon>
@@ -75,13 +76,22 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='x64'">
     <PreBuildEvent>taskkill /IM EverythingToolbar.Launcher.exe /F 2&gt;nul &amp;set errorlevel=0
 xcopy $(SolutionDir)EverythingSDK\x64\$(Configuration)\Everything64.dll $(TargetDir) /r /y
 Exit 0</PreBuildEvent>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)'=='ARM64'">
+    <PreBuildEvent>taskkill /IM EverythingToolbar.Launcher.exe /F 2&gt;nul &amp;set errorlevel=0
+xcopy $(SolutionDir)EverythingSDK\ARM64\$(Configuration)\Everything64.dll $(TargetDir) /r /y
+Exit 0</PreBuildEvent>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'"></PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'"></PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/EverythingToolbar.sln
+++ b/EverythingToolbar.sln
@@ -24,6 +24,8 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
 		Release|x64 = Release|x64
+		Debug|ARM64 = Debug|ARM64
+		Release|ARM64 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C8BB766A-D7BC-47F5-A0E7-D3225DD1F469}.Debug|x64.ActiveCfg = Debug|x64
@@ -42,6 +44,23 @@ Global
 		{C3F92B04-FFA3-40DE-A64A-00019C5A8852}.Debug|x64.Build.0 = Debug|x64
 		{C3F92B04-FFA3-40DE-A64A-00019C5A8852}.Release|x64.ActiveCfg = Release|x64
 		{C3F92B04-FFA3-40DE-A64A-00019C5A8852}.Release|x64.Build.0 = Release|x64
+
+		{C8BB766A-D7BC-47F5-A0E7-D3225DD1F469}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{C8BB766A-D7BC-47F5-A0E7-D3225DD1F469}.Debug|ARM64.Build.0 = Debug|ARM64
+		{C8BB766A-D7BC-47F5-A0E7-D3225DD1F469}.Release|ARM64.ActiveCfg = Release|ARM64
+		{C8BB766A-D7BC-47F5-A0E7-D3225DD1F469}.Release|ARM64.Build.0 = Release|ARM64
+		{FC46FED2-0B98-497F-8F88-037A0780ACF2}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{FC46FED2-0B98-497F-8F88-037A0780ACF2}.Debug|ARM64.Build.0 = Debug|ARM64
+		{FC46FED2-0B98-497F-8F88-037A0780ACF2}.Release|ARM64.ActiveCfg = Release|ARM64
+		{FC46FED2-0B98-497F-8F88-037A0780ACF2}.Release|ARM64.Build.0 = Release|ARM64
+		{BF806AC1-5839-4DAA-90F2-9D6F2B65C0FD}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{BF806AC1-5839-4DAA-90F2-9D6F2B65C0FD}.Debug|ARM64.Build.0 = Debug|ARM64
+		{BF806AC1-5839-4DAA-90F2-9D6F2B65C0FD}.Release|ARM64.ActiveCfg = Release|ARM64
+		{BF806AC1-5839-4DAA-90F2-9D6F2B65C0FD}.Release|ARM64.Build.0 = Release|ARM64
+		{C3F92B04-FFA3-40DE-A64A-00019C5A8852}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{C3F92B04-FFA3-40DE-A64A-00019C5A8852}.Debug|ARM64.Build.0 = Debug|ARM64
+		{C3F92B04-FFA3-40DE-A64A-00019C5A8852}.Release|ARM64.ActiveCfg = Release|ARM64
+		{C3F92B04-FFA3-40DE-A64A-00019C5A8852}.Release|ARM64.Build.0 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/EverythingToolbar/EverythingToolbar.csproj
+++ b/EverythingToolbar/EverythingToolbar.csproj
@@ -9,6 +9,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
+    <Platforms>x64;ARM64</Platforms>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
@@ -252,6 +253,10 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'"></PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'"></PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
* The adoption of Windows on ARM (WoA) devices is steadily increasing, yet many application are still not available for this platform.
* Currently, Everythingtoolbar application build support is not provided for Windows ARM64 and thus users/developers were facing difficulties using popular Everythingtoolbar application natively.
* This PR introduces support for building Everythingtoolbar application on Windows ARM64, improving accessibility for developers and end users on this emerging platform.
* Subsequent PRs would be raised for supporting installer for Everythingtoolbar and CI support for this platform, since GitHub Actions now offer native CI runners for Windows on ARM devices (windows-11-arm), enabling automated builds and testing.