### PR TITLE
Implement wrap-around navigation for search results list

### DIFF
--- a/EverythingToolbar/Controls/SearchResultsView.xaml.cs
+++ b/EverythingToolbar/Controls/SearchResultsView.xaml.cs
@@ -268,30 +268,40 @@ namespace EverythingToolbar.Controls
             }
             else if (e.Key == Key.Up)
             {
-                bool isWrapEnabled = ToolbarSettings.User.ListFocusBehavior != FocusBehavior.Clamp;
-                bool forceSearchBox = ToolbarSettings.User.ListFocusBehavior == FocusBehavior.RepeatWithSearch;
-
-                if (
-                    isWrapEnabled
-                    && (
-                        (SearchResultsListView.SelectedIndex == 0 && ToolbarSettings.User.IsAutoSelectFirstResult && !forceSearchBox)
-                        || (SelectedItem == null && (!ToolbarSettings.User.IsAutoSelectFirstResult || forceSearchBox))
-                    )
-                )
+                if (SearchResultsListView.SelectedIndex > 0)
                 {
-                    ForwardKeyPressToControl(SearchResultsListView, Key.End);
+                    SelectPreviousSearchResult();
                 }
-                else if (
-                    SearchResultsListView.SelectedIndex == 0
-                    && (!ToolbarSettings.User.IsAutoSelectFirstResult || !ToolbarSettings.User.IsSearchAsYouType || forceSearchBox)
-                )
+                else if (SearchResultsListView.SelectedIndex == 0)
                 {
-                    SearchResultsListView.SelectedIndex = -1;
-                    EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
+                    switch (ToolbarSettings.User.ListFocusBehavior)
+                    {
+                        case FocusBehavior.Repeat:
+                            ForwardKeyPressToControl(SearchResultsListView, Key.End);
+                            break;
+                        case FocusBehavior.RepeatWithSearch:
+                            SearchResultsListView.SelectedIndex = -1;
+                            EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
+                            break;
+                        case FocusBehavior.Clamp:
+                        default:
+                            if (!ToolbarSettings.User.IsAutoSelectFirstResult)
+                            {
+                                SearchResultsListView.SelectedIndex = -1;
+                                EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
+                            }
+                            break;
+                    }
                 }
                 else
                 {
-                    SelectPreviousSearchResult();
+                    // SelectedIndex == -1 (e.g. from SearchBox)
+                    if (ToolbarSettings.User.ListFocusBehavior != FocusBehavior.Clamp)
+                    {
+                        // Wrap to end
+                        SearchResultsListView.Focus();
+                        ForwardKeyPressToControl(SearchResultsListView, Key.End);
+                    }
                 }
 
                 e.Handled = true;
@@ -300,20 +310,19 @@ namespace EverythingToolbar.Controls
             {
                 if (SearchResultsListView.SelectedIndex == SearchResultsListView.Items.Count - 1)
                 {
-                    bool isWrapEnabled = ToolbarSettings.User.ListFocusBehavior != FocusBehavior.Clamp;
-                    bool forceSearchBox = ToolbarSettings.User.ListFocusBehavior == FocusBehavior.RepeatWithSearch;
-
-                    if (isWrapEnabled)
+                    switch (ToolbarSettings.User.ListFocusBehavior)
                     {
-                        if (ToolbarSettings.User.IsAutoSelectFirstResult && !forceSearchBox)
-                        {
+                        case FocusBehavior.Repeat:
                             SelectNthSearchResult(0);
-                        }
-                        else
-                        {
+                            break;
+                        case FocusBehavior.RepeatWithSearch:
                             SearchResultsListView.SelectedIndex = -1;
                             EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
-                        }
+                            break;
+                        case FocusBehavior.Clamp:
+                        default:
+                            // Do nothing
+                            break;
                     }
                 }
                 else

--- a/EverythingToolbar/Controls/SearchResultsView.xaml.cs
+++ b/EverythingToolbar/Controls/SearchResultsView.xaml.cs
@@ -270,14 +270,19 @@ namespace EverythingToolbar.Controls
             {
                 if (SearchResultsListView.SelectedIndex == 0)
                 {
-                    if (ToolbarSettings.User.IsListWrapAroundEnabled)
+                    switch (ToolbarSettings.User.ListFocusBehavior)
                     {
-                        SelectNthSearchResult(SearchResultsListView.Items.Count - 1);
-                    }
-                    else if (!ToolbarSettings.User.IsAutoSelectFirstResult || !ToolbarSettings.User.IsSearchAsYouType)
-                    {
-                        SearchResultsListView.SelectedIndex = -1;
-                        EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
+                        case FocusBehavior.Repeat:
+                            SelectNthSearchResult(SearchResultsListView.Items.Count - 1);
+                            break;
+                        case FocusBehavior.RepeatWithSearch:
+                            SearchResultsListView.SelectedIndex = -1;
+                            EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
+                            break;
+                        case FocusBehavior.Clamp:
+                        default:
+                            // Do nothing
+                            break;
                     }
                 }
                 else
@@ -289,9 +294,22 @@ namespace EverythingToolbar.Controls
             }
             else if (e.Key == Key.Down)
             {
-                if (ToolbarSettings.User.IsListWrapAroundEnabled && SearchResultsListView.SelectedIndex == SearchResultsListView.Items.Count - 1)
+                if (SearchResultsListView.SelectedIndex == SearchResultsListView.Items.Count - 1)
                 {
-                    SelectNthSearchResult(0);
+                    switch (ToolbarSettings.User.ListFocusBehavior)
+                    {
+                        case FocusBehavior.Repeat:
+                            SelectNthSearchResult(0);
+                            break;
+                        case FocusBehavior.RepeatWithSearch:
+                            SearchResultsListView.SelectedIndex = -1;
+                            EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
+                            break;
+                        case FocusBehavior.Clamp:
+                        default:
+                            // Do nothing
+                            break;
+                    }
                 }
                 else
                 {

--- a/EverythingToolbar/Controls/SearchResultsView.xaml.cs
+++ b/EverythingToolbar/Controls/SearchResultsView.xaml.cs
@@ -268,22 +268,26 @@ namespace EverythingToolbar.Controls
             }
             else if (e.Key == Key.Up)
             {
-                if (SearchResultsListView.SelectedIndex == 0)
+                bool isWrapEnabled = ToolbarSettings.User.ListFocusBehavior != FocusBehavior.Clamp;
+                bool forceSearchBox = ToolbarSettings.User.ListFocusBehavior == FocusBehavior.RepeatWithSearch;
+
+                if (
+                    isWrapEnabled
+                    && (
+                        (SearchResultsListView.SelectedIndex == 0 && ToolbarSettings.User.IsAutoSelectFirstResult && !forceSearchBox)
+                        || (SelectedItem == null && (!ToolbarSettings.User.IsAutoSelectFirstResult || forceSearchBox))
+                    )
+                )
                 {
-                    switch (ToolbarSettings.User.ListFocusBehavior)
-                    {
-                        case FocusBehavior.Repeat:
-                            SelectNthSearchResult(SearchResultsListView.Items.Count - 1);
-                            break;
-                        case FocusBehavior.RepeatWithSearch:
-                            SearchResultsListView.SelectedIndex = -1;
-                            EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
-                            break;
-                        case FocusBehavior.Clamp:
-                        default:
-                            // Do nothing
-                            break;
-                    }
+                    ForwardKeyPressToControl(SearchResultsListView, Key.End);
+                }
+                else if (
+                    SearchResultsListView.SelectedIndex == 0
+                    && (!ToolbarSettings.User.IsAutoSelectFirstResult || !ToolbarSettings.User.IsSearchAsYouType || forceSearchBox)
+                )
+                {
+                    SearchResultsListView.SelectedIndex = -1;
+                    EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
                 }
                 else
                 {
@@ -296,19 +300,20 @@ namespace EverythingToolbar.Controls
             {
                 if (SearchResultsListView.SelectedIndex == SearchResultsListView.Items.Count - 1)
                 {
-                    switch (ToolbarSettings.User.ListFocusBehavior)
+                    bool isWrapEnabled = ToolbarSettings.User.ListFocusBehavior != FocusBehavior.Clamp;
+                    bool forceSearchBox = ToolbarSettings.User.ListFocusBehavior == FocusBehavior.RepeatWithSearch;
+
+                    if (isWrapEnabled)
                     {
-                        case FocusBehavior.Repeat:
+                        if (ToolbarSettings.User.IsAutoSelectFirstResult && !forceSearchBox)
+                        {
                             SelectNthSearchResult(0);
-                            break;
-                        case FocusBehavior.RepeatWithSearch:
+                        }
+                        else
+                        {
                             SearchResultsListView.SelectedIndex = -1;
                             EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
-                            break;
-                        case FocusBehavior.Clamp:
-                        default:
-                            // Do nothing
-                            break;
+                        }
                     }
                 }
                 else

--- a/EverythingToolbar/Controls/SearchResultsView.xaml.cs
+++ b/EverythingToolbar/Controls/SearchResultsView.xaml.cs
@@ -268,13 +268,17 @@ namespace EverythingToolbar.Controls
             }
             else if (e.Key == Key.Up)
             {
-                if (
-                    SearchResultsListView.SelectedIndex == 0
-                    && (!ToolbarSettings.User.IsAutoSelectFirstResult || !ToolbarSettings.User.IsSearchAsYouType)
-                )
+                if (SearchResultsListView.SelectedIndex == 0)
                 {
-                    SearchResultsListView.SelectedIndex = -1;
-                    EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
+                    if (ToolbarSettings.User.IsListWrapAroundEnabled)
+                    {
+                        SelectNthSearchResult(SearchResultsListView.Items.Count - 1);
+                    }
+                    else if (!ToolbarSettings.User.IsAutoSelectFirstResult || !ToolbarSettings.User.IsSearchAsYouType)
+                    {
+                        SearchResultsListView.SelectedIndex = -1;
+                        EventDispatcher.Instance.InvokeSearchBoxFocused(this, EventArgs.Empty);
+                    }
                 }
                 else
                 {
@@ -285,7 +289,14 @@ namespace EverythingToolbar.Controls
             }
             else if (e.Key == Key.Down)
             {
-                SelectNextSearchResult();
+                if (ToolbarSettings.User.IsListWrapAroundEnabled && SearchResultsListView.SelectedIndex == SearchResultsListView.Items.Count - 1)
+                {
+                    SelectNthSearchResult(0);
+                }
+                else
+                {
+                    SelectNextSearchResult();
+                }
                 e.Handled = true;
             }
             else if (e.Key == Key.PageUp || e.Key == Key.PageDown || e.Key == Key.Home || e.Key == Key.End)

--- a/EverythingToolbar/Data/FocusBehavior.cs
+++ b/EverythingToolbar/Data/FocusBehavior.cs
@@ -1,0 +1,9 @@
+namespace EverythingToolbar.Data
+{
+    public enum FocusBehavior
+    {
+        Clamp,
+        Repeat,
+        RepeatWithSearch
+    }
+}

--- a/EverythingToolbar/Properties/Resources.Designer.cs
+++ b/EverythingToolbar/Properties/Resources.Designer.cs
@@ -1248,6 +1248,24 @@ namespace EverythingToolbar.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to List wrap around.
+        /// </summary>
+        public static string SettingsListWrapAround {
+            get {
+                return ResourceManager.GetString("SettingsListWrapAround", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allows navigating from the bottom to the top of the list and vice versa using arrow keys.
+        /// </summary>
+        public static string SettingsListWrapAroundHelp {
+            get {
+                return ResourceManager.GetString("SettingsListWrapAroundHelp", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Choose the layout for search results.
         /// </summary>
         public static string SettingsViewLayoutHelp {

--- a/EverythingToolbar/Properties/Resources.Designer.cs
+++ b/EverythingToolbar/Properties/Resources.Designer.cs
@@ -1248,20 +1248,47 @@ namespace EverythingToolbar.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to List wrap around.
+        ///   Looks up a localized string similar to Clamp.
         /// </summary>
-        public static string SettingsListWrapAround {
+        public static string FocusBehaviorClamp {
             get {
-                return ResourceManager.GetString("SettingsListWrapAround", resourceCulture);
+                return ResourceManager.GetString("FocusBehaviorClamp", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allows navigating from the bottom to the top of the list and vice versa using arrow keys.
+        ///   Looks up a localized string similar to Repeat.
         /// </summary>
-        public static string SettingsListWrapAroundHelp {
+        public static string FocusBehaviorRepeat {
             get {
-                return ResourceManager.GetString("SettingsListWrapAroundHelp", resourceCulture);
+                return ResourceManager.GetString("FocusBehaviorRepeat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repeat with search.
+        /// </summary>
+        public static string FocusBehaviorRepeatWithSearch {
+            get {
+                return ResourceManager.GetString("FocusBehaviorRepeatWithSearch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Result list focus.
+        /// </summary>
+        public static string SettingsListFocusBehavior {
+            get {
+                return ResourceManager.GetString("SettingsListFocusBehavior", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Controls how the focus behaves when navigating the result list.
+        /// </summary>
+        public static string SettingsListFocusBehaviorHelp {
+            get {
+                return ResourceManager.GetString("SettingsListFocusBehaviorHelp", resourceCulture);
             }
         }
 

--- a/EverythingToolbar/Properties/Resources.resx
+++ b/EverythingToolbar/Properties/Resources.resx
@@ -642,10 +642,19 @@
   <data name="ShortcutOpenSystemContextMenu" xml:space="preserve">
     <value>Open system context menu</value>
   </data>
-  <data name="SettingsListWrapAround" xml:space="preserve">
-    <value>List wrap around</value>
+  <data name="SettingsListFocusBehavior" xml:space="preserve">
+    <value>Result list focus</value>
   </data>
-  <data name="SettingsListWrapAroundHelp" xml:space="preserve">
-    <value>Allows navigating from the bottom to the top of the list and vice versa using arrow keys</value>
+  <data name="SettingsListFocusBehaviorHelp" xml:space="preserve">
+    <value>Controls how the focus behaves when navigating the result list</value>
+  </data>
+  <data name="FocusBehaviorClamp" xml:space="preserve">
+    <value>Clamp</value>
+  </data>
+  <data name="FocusBehaviorRepeat" xml:space="preserve">
+    <value>Repeat</value>
+  </data>
+  <data name="FocusBehaviorRepeatWithSearch" xml:space="preserve">
+    <value>Repeat with search</value>
   </data>
 </root>

--- a/EverythingToolbar/Properties/Resources.resx
+++ b/EverythingToolbar/Properties/Resources.resx
@@ -642,4 +642,10 @@
   <data name="ShortcutOpenSystemContextMenu" xml:space="preserve">
     <value>Open system context menu</value>
   </data>
+  <data name="SettingsListWrapAround" xml:space="preserve">
+    <value>List wrap around</value>
+  </data>
+  <data name="SettingsListWrapAroundHelp" xml:space="preserve">
+    <value>Allows navigating from the bottom to the top of the list and vice versa using arrow keys</value>
+  </data>
 </root>

--- a/EverythingToolbar/Settings/Search.xaml
+++ b/EverythingToolbar/Settings/Search.xaml
@@ -75,10 +75,14 @@
                     BorderBrush="{ui:ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1,1,1,0"
                     CornerRadius="0">
-                <controls:SettingItem Title="{x:Static properties:Resources.SettingsListWrapAround}"
-                                      HelpText="{x:Static properties:Resources.SettingsListWrapAroundHelp}">
+                <controls:SettingItem Title="{x:Static properties:Resources.SettingsListFocusBehavior}"
+                                      HelpText="{x:Static properties:Resources.SettingsListFocusBehaviorHelp}">
                     <controls:SettingItem.SettingContent>
-                        <ui:ToggleSwitch IsChecked="{Binding Source={x:Static local:ToolbarSettings.User}, Path=IsListWrapAroundEnabled, Mode=TwoWay}" />
+                        <ComboBox HorizontalAlignment="Right"
+                                  ItemsSource="{Binding FocusBehaviorItems}"
+                                  DisplayMemberPath="Key"
+                                  SelectedValuePath="Value"
+                                  SelectedValue="{Binding Source={x:Static local:ToolbarSettings.User}, Path=ListFocusBehavior, Mode=TwoWay}" />
                     </controls:SettingItem.SettingContent>
                 </controls:SettingItem>
             </Border>

--- a/EverythingToolbar/Settings/Search.xaml
+++ b/EverythingToolbar/Settings/Search.xaml
@@ -73,6 +73,18 @@
             <Border Padding="16"
                     Background="{ui:ThemeResource CardBackgroundFillColorDefaultBrush}"
                     BorderBrush="{ui:ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1,1,1,0"
+                    CornerRadius="0">
+                <controls:SettingItem Title="{x:Static properties:Resources.SettingsListWrapAround}"
+                                      HelpText="{x:Static properties:Resources.SettingsListWrapAroundHelp}">
+                    <controls:SettingItem.SettingContent>
+                        <ui:ToggleSwitch IsChecked="{Binding Source={x:Static local:ToolbarSettings.User}, Path=IsListWrapAroundEnabled, Mode=TwoWay}" />
+                    </controls:SettingItem.SettingContent>
+                </controls:SettingItem>
+            </Border>
+            <Border Padding="16"
+                    Background="{ui:ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ui:ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1,1,1,1"
                     CornerRadius="0, 0, 8, 8">
                 <controls:SettingItem Title="{x:Static properties:Resources.SettingsDoubleClickToOpen}"

--- a/EverythingToolbar/Settings/Search.xaml.cs
+++ b/EverythingToolbar/Settings/Search.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Windows;
 using EverythingToolbar.Data;
 using EverythingToolbar.Helpers;

--- a/EverythingToolbar/Settings/Search.xaml.cs
+++ b/EverythingToolbar/Settings/Search.xaml.cs
@@ -1,5 +1,8 @@
-﻿using System.Windows;
+﻿using System.Collections.Generic;
+using System.Windows;
+using EverythingToolbar.Data;
 using EverythingToolbar.Helpers;
+using EverythingToolbar.Properties;
 
 namespace EverythingToolbar.Settings
 {
@@ -8,11 +11,22 @@ namespace EverythingToolbar.Settings
         public Search()
         {
             InitializeComponent();
+            DataContext = new SearchViewModel();
         }
 
         private void OnClearHistoryClicked(object sender, RoutedEventArgs e)
         {
             HistoryManager.Instance.ClearHistory();
         }
+    }
+
+    public class SearchViewModel
+    {
+        public List<KeyValuePair<string, FocusBehavior>> FocusBehaviorItems { get; } =
+        [
+            new(Resources.FocusBehaviorClamp, FocusBehavior.Clamp),
+            new(Resources.FocusBehaviorRepeat, FocusBehavior.Repeat),
+            new(Resources.FocusBehaviorRepeatWithSearch, FocusBehavior.RepeatWithSearch),
+        ];
     }
 }

--- a/EverythingToolbar/ToolbarSettings.cs
+++ b/EverythingToolbar/ToolbarSettings.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Runtime.CompilerServices;
 using Config.Net;
+using EverythingToolbar.Data;
 using EverythingToolbar.Helpers;
 
 namespace EverythingToolbar
@@ -13,6 +14,9 @@ namespace EverythingToolbar
 
         [Option(DefaultValue = false)]
         bool IsRegExEnabled { get; set; }
+
+        [Option(DefaultValue = FocusBehavior.Repeat)]
+        FocusBehavior ListFocusBehavior { get; set; }
 
         [Option(DefaultValue = false)]
         bool IsMatchPath { get; set; }
@@ -110,8 +114,7 @@ namespace EverythingToolbar
         [Option(DefaultValue = true)]
         bool IsHomeEndNavigateResults { get; set; }
 
-        [Option(DefaultValue = true)]
-        bool IsListWrapAroundEnabled { get; set; }
+
 
         [Option(DefaultValue = true)]
         bool IsSearchAsYouType { get; set; }
@@ -580,14 +583,16 @@ namespace EverythingToolbar
             }
         }
 
-        public bool IsListWrapAroundEnabled
+
+
+        public FocusBehavior ListFocusBehavior
         {
-            get => settings.IsListWrapAroundEnabled;
+            get => settings.ListFocusBehavior;
             set
             {
-                if (settings.IsListWrapAroundEnabled != value)
+                if (settings.ListFocusBehavior != value)
                 {
-                    settings.IsListWrapAroundEnabled = value;
+                    settings.ListFocusBehavior = value;
                     OnPropertyChanged();
                 }
             }

--- a/EverythingToolbar/ToolbarSettings.cs
+++ b/EverythingToolbar/ToolbarSettings.cs
@@ -111,6 +111,9 @@ namespace EverythingToolbar
         bool IsHomeEndNavigateResults { get; set; }
 
         [Option(DefaultValue = true)]
+        bool IsListWrapAroundEnabled { get; set; }
+
+        [Option(DefaultValue = true)]
         bool IsSearchAsYouType { get; set; }
 
         [Option(DefaultValue = false)]
@@ -572,6 +575,19 @@ namespace EverythingToolbar
                 if (settings.IsHomeEndNavigateResults != value)
                 {
                     settings.IsHomeEndNavigateResults = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool IsListWrapAroundEnabled
+        {
+            get => settings.IsListWrapAroundEnabled;
+            set
+            {
+                if (settings.IsListWrapAroundEnabled != value)
+                {
+                    settings.IsListWrapAroundEnabled = value;
                     OnPropertyChanged();
                 }
             }


### PR DESCRIPTION
This PR implements a wrap-around navigation feature for the search results list, 
Ref: #302 , #707

- Add `IsListWrapAroundEnabled` setting to [ToolbarSettings]
- Add "List wrap around" toggle to Search settings UI
- Implement navigation logic in [SearchResultsView] to loop selection with Up/Down keys
- Add localization resources for the new setting