### PR TITLE
Add copy file name context menu action

### DIFF
--- a/EverythingToolbar.App/Search/SearchResultActions.cs
+++ b/EverythingToolbar.App/Search/SearchResultActions.cs
@@ -105,6 +105,19 @@ namespace EverythingToolbar.App.Search
             }
         }
 
+        public void CopyFileNameToClipboard(SearchResult r)
+        {
+            try
+            {
+                clipboard.SetText(r.FileName);
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Failed to copy file name.");
+                notifier.ShowError("MessageBoxFailedToCopyFileName", e.Message);
+            }
+        }
+
         public void ShowProperties(SearchResult r)
         {
             shellDialogs.ShowFileProperties(r.FullPathAndFileName);

--- a/EverythingToolbar/Controls/SearchResultsView.xaml
+++ b/EverythingToolbar/Controls/SearchResultsView.xaml
@@ -46,6 +46,9 @@
         <Separator />
         <MenuItem Click="CopyPathToClipBoard" Header="{x:Static properties:Resources.ContextMenuCopyFullName}" />
         <MenuItem
+          Click="CopyFileNameToClipboard"
+          Header="{x:Static properties:Resources.ContextMenuCopyFileName}" />
+        <MenuItem
           Click="CopyFile"
           Header="{x:Static properties:Resources.ContextMenuCopyFile}"
           Icon="&#xE8C8;" />

--- a/EverythingToolbar/Controls/SearchResultsView.xaml.cs
+++ b/EverythingToolbar/Controls/SearchResultsView.xaml.cs
@@ -286,6 +286,11 @@ namespace EverythingToolbar.Controls
             _viewModel.CopySelectedPath();
         }
 
+        private void CopyFileNameToClipboard(object sender, RoutedEventArgs e)
+        {
+            _viewModel.CopySelectedFileName();
+        }
+
         private void OpenWith(object sender, RoutedEventArgs e)
         {
             _viewModel.OpenSelectedWith();

--- a/EverythingToolbar/Properties/Resources.Designer.cs
+++ b/EverythingToolbar/Properties/Resources.Designer.cs
@@ -166,6 +166,15 @@ namespace EverythingToolbar.Properties {
                 return ResourceManager.GetString("ContextMenuCopyFile", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Copy File Name to Clipboard.
+        /// </summary>
+        public static string ContextMenuCopyFileName {
+            get {
+                return ResourceManager.GetString("ContextMenuCopyFileName", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Copy Full Name to Clipboard.
@@ -488,6 +497,15 @@ namespace EverythingToolbar.Properties {
         public static string MessageBoxFailedToCopyFile {
             get {
                 return ResourceManager.GetString("MessageBoxFailedToCopyFile", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to copy file name..
+        /// </summary>
+        public static string MessageBoxFailedToCopyFileName {
+            get {
+                return ResourceManager.GetString("MessageBoxFailedToCopyFileName", resourceCulture);
             }
         }
         

--- a/EverythingToolbar/Properties/Resources.resx
+++ b/EverythingToolbar/Properties/Resources.resx
@@ -126,6 +126,9 @@
   <data name="ContextMenuCopyFile" xml:space="preserve">
     <value>Copy</value>
   </data>
+  <data name="ContextMenuCopyFileName" xml:space="preserve">
+    <value>Copy File Name to Clipboard</value>
+  </data>
   <data name="ContextMenuCopyFullName" xml:space="preserve">
     <value>Copy Full Name to Clipboard</value>
   </data>
@@ -200,6 +203,9 @@
   </data>
   <data name="MessageBoxFailedToCopyFile" xml:space="preserve">
     <value>Failed to copy file.</value>
+  </data>
+  <data name="MessageBoxFailedToCopyFileName" xml:space="preserve">
+    <value>Failed to copy file name.</value>
   </data>
   <data name="MessageBoxFailedToCopyPath" xml:space="preserve">
     <value>Failed to copy path.</value>

--- a/EverythingToolbar/Search/SearchCommands.cs
+++ b/EverythingToolbar/Search/SearchCommands.cs
@@ -169,6 +169,9 @@ namespace EverythingToolbar.Search
         public void CopySelectedPath(SearchResult? target = null) =>
             Act(target, _actions.CopyPathToClipboard, hide: false, clearSelection: false);
 
+        public void CopySelectedFileName(SearchResult? target = null) =>
+            Act(target, _actions.CopyFileNameToClipboard, hide: false, clearSelection: false);
+
         public void ShowSelectedWindowsContextMenu(SearchResult? target = null) =>
             Act(target, _actions.ShowWindowsContextMenu, hide: false, clearSelection: false);
 

--- a/EverythingToolbar/ViewModels/SearchResultsViewModel.cs
+++ b/EverythingToolbar/ViewModels/SearchResultsViewModel.cs
@@ -56,6 +56,8 @@ namespace EverythingToolbar.ViewModels
 
         public void CopySelectedPath() => _commands.CopySelectedPath();
 
+        public void CopySelectedFileName() => _commands.CopySelectedFileName();
+
         public void PreviewSelected() => _commands.PreviewSelected();
 
         public void ShowSelectedWindowsContextMenu() => _commands.ShowSelectedWindowsContextMenu();


### PR DESCRIPTION
## Checklist

- [x] I have read the contribution guidelines

## Summary

This PR implements the context-menu alternative discussed in #594 by adding **Copy File Name to Clipboard** below the existing full-name/full-path copy action.

The command follows the existing action flow from `SearchResultsView` through `SearchResultsViewModel` and `SearchCommands` to `SearchResultActions`. It writes `SearchResult.FileName` to the existing clipboard abstraction.

Because `SearchResult.FileName` is derived with `Path.GetFileName(FullPathAndFileName)`, the copied value excludes the parent path while retaining the complete file name and extension, including names containing multiple dots.

Clipboard failures use the same logging and localized notification pattern as the existing copy actions. The window remains open and the selected result remains selected.

No keyboard shortcut is added in this proposal. `Ctrl+C` and `Ctrl+Shift+C` already perform the existing copy-file and copy-path actions, and #594 explicitly lists a menu item as an alternative. This preserves the current keyboard behavior while providing a focused implementation for the maintainer to evaluate.

Only neutral English resource strings are added. Localized resources are intentionally left to the project's Crowdin workflow and fall back to English until translations are available.

## Related issue

Addresses #594

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] UI change
- [ ] Documentation update
- [ ] Refactoring / maintenance

## Testing

Manually tested with the **Search icon / Launcher** variant on Windows `10.0.26200.0`:

- Confirmed that the new context-menu action is displayed.
- Confirmed that it copies only the file name and extension without the parent path.
- Confirmed that the existing copy-file and copy-path actions remain available.

## Screenshots or recordings

A screenshot can be added after producing a clean build from this branch.