### PR TITLE
Restore application font in settings menus

### DIFF
--- a/EverythingToolbar/Controls/SettingsControl.xaml
+++ b/EverythingToolbar/Controls/SettingsControl.xaml
@@ -14,7 +14,9 @@
       Style="{DynamicResource TabBarButtonStyle}"
       ToolTip="{x:Static properties:Resources.SettingsSortBy}">
       <Button.ContextMenu>
-        <ContextMenu Name="SortByMenu" FontFamily="Segoe UI Variable Text, Segoe UI">
+        <ContextMenu
+          Name="SortByMenu"
+          FontFamily="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}, Path=FontFamily}">
           <MenuItem
             Click="OnSortByClicked"
             Header="{x:Static properties:Resources.SortByName}"
@@ -98,7 +100,7 @@
       Style="{DynamicResource TabBarButtonStyle}"
       ToolTip="{x:Static properties:Resources.SettingsPreferences}">
       <Button.ContextMenu>
-        <ContextMenu FontFamily="Segoe UI Variable Text, Segoe UI">
+        <ContextMenu FontFamily="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}, Path=FontFamily}">
           <MenuItem
             Header="{x:Static properties:Resources.SettingsRegularExpressions}"
             IsCheckable="True"


### PR DESCRIPTION
## Checklist

- [x] I have read the contribution guidelines

## Summary

This PR restores locale-aware font inheritance for the sort and settings context menus in `SettingsControl`.

The menus currently hard-code `Segoe UI Variable Text, Segoe UI`. For Simplified Chinese this selects a different CJK fallback, causing the menu text to look inconsistent with the rest of the application.

This change restores the containing window's `FontFamily` binding previously used by the project:

```xaml
FontFamily="{Binding RelativeSource={RelativeSource AncestorType={x:Type Window}}, Path=FontFamily}"
```
The exact ancestor binding is intentional and follows the implementation previously used for #645 and discussed in #666.

No translations or menu behavior are changed.

## Related issue

Fixes #763 

Related to #645 and #666.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] UI change
- [ ] Documentation update
- [ ] Refactoring / maintenance

## Testing

Manually tested with:

Windows 11, OS build 26200.0
Search icon / Launcher
Simplified Chinese UI
EverythingToolbar 3.0.1.0 affected build and patched local comparison build

Confirmed that the quick settings menu inherits the window font and visually matches the surrounding interface.

The sort menu and Deskband variant were not independently tested in this build.

## Screenshots or recordings

See #763 for the before-and-after comparison.